### PR TITLE
Tech typo : adding the lib/ repo to the command line

### DIFF
--- a/MiniTutorial/Index.xyl
+++ b/MiniTutorial/Index.xyl
@@ -58,7 +58,7 @@
   <p>Pour respecter cette recommandation, il faudra user d'un lien symbolique
   lors de l'installation, par exemple :</p>
   <pre><code class="language-shell">$ git clone http://git.hoa-project.net/Central.git /usr/local/lib/Hoa.central
-$ ln -s /usr/local/Hoa.central/Hoa /usr/local/lib/Hoa</code></pre>
+$ ln -s /usr/local/lib/Hoa.central/Hoa /usr/local/lib/Hoa</code></pre>
 
   <h3 id="Creer_notre_application" for="main-toc">Créer notre application</h3>
 


### PR DESCRIPTION
The command line was not in concordance with the advice : "Nous conseillons donc de l'installer dans le répertoire /usr/local/lib/"
