### PR TITLE
Add details about commit type and title structure in the contributor guide.

### DIFF
--- a/Contributor/En/Guide.xyl
+++ b/Contributor/En/Guide.xyl
@@ -389,8 +389,43 @@ $ git commit</code></pre>
   <p>If you made a mistake while commiting, no worry, you are still able to edit
   your commit message by running:</p>
   <pre><code class="language-shell">$ git commit --amend</code></pre>
-  <p>Do not edit the <code>CHANGELOG.md</code> file. It is automatically
-  generated.</p>
+  <p>Do not edit this <code>CHANGELOG.md</code> file. It is automatically
+ generated.</p>
+
+  <h3 id="Commit_message_structure" for="main-toc">Commit message structure</h3>
+
+  <p>As seen in the previous section, a commit title must be less than 50
+  characters long. This title must be precise and straightforward and describe
+  the corresponding modifications.</p>
+
+  <p>Use the following structure to write the title
+  <code>type(scope) title</code>.<p>
+
+  <p>This structure allows you to easily describe the type of the commit in
+  question and what parts of the code are affected. We have identified several
+  categories of commits in a project:</p>
+
+  <ul>
+    <li><code>chore</code> for addressing quality issues,</li>
+    <li><code>fix</code> for fixing a bug,</li>
+    <li><code>feat</code> for creating a new feature,</li>
+    <li><code>depr</code> for a deprecation notice,</li>
+    <li><code>sec</code> for addressing security issues,</li>
+    <li><code>doc</code> for modifying documentation,</li>
+    <li><code>test</code> for testing a modification,</li>
+    <li><code>undef</code> for anything else.</li>
+  </ul>
+
+  <p>For example, </p>
+
+  <ul>
+    <li><code>feat(permission) Search backward bla bla.</code>,</li>
+    <li><code>fix(user) `getName` is incorrectly computing its value.</code></li>
+  </ul>
+
+  <p>The goal is to generate a <code>CHANGELOG</code> file as suggested by
+  <a href="http://keepachangelog.com/en/1.0.0/">Keep a Changelog</a>,
+  with “Added”, “Bug fixes”, “Removed“ Sections, and the date of releases.</p>
 
   <h3 id="Review_all_your_commits" for="main-toc">Review all your commits</h3>
 

--- a/Contributor/Fr/Guide.xyl
+++ b/Contributor/Fr/Guide.xyl
@@ -425,6 +425,43 @@ $ git commit</code></pre>
   <p>Ne modifiez pas le fichier <code>CHANGELOG.md</code>. Il est
   généré automatiquement.</p>
 
+  <h3 id="Commit_message_structure" for="main-toc">Structure d'un message de commit</h3>
+
+  <p>Comme nous l'avons vu précédemment, le titre d'un commit fait 50 caractères
+  au maximum. Ce titre se doit d'être précis et sa lecture
+  doit permettre d'identifier la modification apportée.</p>
+
+  <p>Pour faciliter l'écriture de ce titre, nous avons défini une structure
+  type&nbsp;: <code>type(scope) title</code>.<p>
+
+  <p>Cette structure permet de décrire quel est le type de commit et sur quoi il
+  porte. Nous avons en effet isolé plusieurs types récurrents dans un
+  projet&nbsp;:</p>
+
+  <ul>
+    <li><code>chore</code> pour tout ce qui concerne la « qualité »&nbsp;;</li>
+    <li><code>fix</code> pour un correctif&nbsp;;</li>
+    <li><code>feat</code> pour une nouvelle fonctionnalité&nbsp;;</li>
+    <li><code>depr</code> pour une fonctionnalité dépréciée&nbsp;;</li>
+    <li><code>sec</code> pour une modification liée à la sécurité&nbsp;;</li>
+    <li><code>doc</code> pour tout ce qui se rapporte à la documentation&nbsp;;</li>
+    <li><code>test</code> pour une modification liée aux tests&nbsp;;</li>
+    <li><code>undef</code> pour tout le reste.</li>
+  </ul>
+
+  <p>Nous obtenons par exemple&nbsp;:</p>
+
+  <ul>
+    <li><code>feat(permission) Search backward bla bla.,</code></li>
+    <li><code>fix(user) `getName` is incorrectly computing its value.,</code></li>
+  </ul>
+
+  <p>L'objectif de la normalisation des messages de commit est de permettre la
+  génération d'un fichier <code>CHANGELOG</code> tel que suggéré par
+  <a href="http://keepachangelog.com/fr/1.0.0/">Keep a changelog</a>,
+  avec des sections « Ajouts », « Correctifs », « Suppressions » ainsi que la date
+  de la sortie des versions.</p>
+
   <h3 id="Review_all_your_commits" for="main-toc">Relire tous vos commits</h3>
 
   <p>Parfois vous pourrez exprimer le besoin de <strong>lister</strong> tous vos


### PR DESCRIPTION
Hello !

I finally started to work on the contributor guide update regarding commit types. I've added some details about the commit title structure and the different commit types.

For me it's enough in this part, maybe I'm wrong. What are you thinking about ?