### PR TITLE
Update guide difficulty links

### DIFF
--- a/Contributor/En/Guide.xyl
+++ b/Contributor/En/Guide.xyl
@@ -147,15 +147,14 @@
     <li><code>hard</code>, requires <strong>strong skills</strong> in the code
     and the domain it addresses.</li>
   </ul>
-  <p>Fortunately, boards provide a search engine easing to sort the works based
-  on your profile; thus:</p>
+  <p>You can use the following links to see issues of a specific difficulty:</p>
   <ul>
-    <li><a href="@board:repository=Central&amp;search=difficulty: casual">all
-    the <code>casual</code> works</a>,</li>
-    <li><a href="@board:repository=Central&amp;search=difficulty: medium">all
-    the <code>medium</code> works</a>,</li>
-    <li><a href="@board:repository=Central&amp;search=difficulty: hard">all
-    the <code>hard</code> works</a>.</li>
+    <li><a href="https://github.com/issues?q=is:issue is:open org:hoaproject label:"difficulty: casual" ">all
+    the <code>casual</code> issues</a>,</li>
+    <li><a href="https://github.com/issues?q=is:issue is:open org:hoaproject label:"difficulty: medium" ">all
+    the <code>medium</code> issues</a>,</li>
+    <li><a href="https://github.com/issues?q=is:issue is:open org:hoaproject label:"difficulty: hard" ">all
+    the <code>hard</code> issues</a>.</li>
   </ul>
   <p>Now we know what to do, let's contribute!</p>
 


### PR DESCRIPTION
Fix broken links to waffle board, replacing them with github issue search.

Noticed when was checking the doc.
I think more work would be required to remove all waffle references since they have shut down. 